### PR TITLE
Fix sensor entities showing unknown state and dots in history graph

### DIFF
--- a/custom_components/yolocal/__init__.py
+++ b/custom_components/yolocal/__init__.py
@@ -42,6 +42,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
+    # Perform the first data refresh so the coordinator (and therefore
+    # all entities) have valid state before platforms are set up.
+    await coordinator.async_config_entry_first_refresh()
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/yolocal/coordinator.py
+++ b/custom_components/yolocal/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 from typing import Any
 
 import aiohttp
@@ -22,12 +23,16 @@ from .api.auth import AuthenticationError
 
 _LOGGER = logging.getLogger(__name__)
 
+# Polling interval as fallback when MQTT events are missed
+UPDATE_INTERVAL = timedelta(minutes=5)
+
 
 class YoLocalCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     """Coordinator for YoLink Local devices.
 
     Manages MQTT subscription for real-time updates and provides
-    device state to entities.
+    device state to entities. Falls back to HTTP polling every 5 minutes
+    to ensure state stays current if MQTT events are missed.
     """
 
     def __init__(
@@ -44,6 +49,7 @@ class YoLocalCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             hass,
             _LOGGER,
             name="YoLink Local",
+            update_interval=UPDATE_INTERVAL,
         )
         self._client = client
         self._token_manager = token_manager
@@ -64,15 +70,27 @@ class YoLocalCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         devices = await self._client.get_devices()
         self._devices = {d.device_id: d for d in devices}
 
-        for device in devices:
+        await self._fetch_all_states()
+        await self._connect_mqtt()
+
+    async def _fetch_all_states(self) -> None:
+        """Fetch current state for all devices via HTTP API."""
+        for device in self._devices.values():
             try:
                 state = await self._client.get_state(device)
                 self._states[device.device_id] = state
             except Exception:
-                _LOGGER.warning("Failed to get initial state for %s", device.name)
-                self._states[device.device_id] = {}
+                _LOGGER.warning("Failed to get state for %s", device.name)
+                self._states.setdefault(device.device_id, {})
 
-        await self._connect_mqtt()
+    async def _async_update_data(self) -> dict[str, dict[str, Any]]:
+        """Poll device states via HTTP as a fallback.
+
+        This runs periodically (every 5 minutes) to ensure state stays
+        current even if MQTT events are missed or the connection drops.
+        """
+        await self._fetch_all_states()
+        return self._states.copy()
 
     async def async_shutdown(self) -> None:
         """Shut down the coordinator."""
@@ -103,13 +121,19 @@ class YoLocalCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
 
     @callback
     def _on_device_event(self, event: DeviceEvent) -> None:
-        """Handle a device event from MQTT."""
+        """Handle a device event from MQTT.
+
+        Merges incoming event data with the existing device state so that
+        partial events (e.g. connectivity-only updates) don't wipe out
+        previously known sensor readings like temperature and humidity.
+        """
         device_id = event.device_id
         if device_id not in self._devices:
             _LOGGER.debug("Ignoring event for unknown device: %s", device_id)
             return
 
-        self._states[device_id] = event.data
+        existing = self._states.get(device_id, {})
+        self._states[device_id] = {**existing, **event.data}
         self.async_set_updated_data(self._states.copy())
 
     def get_state(self, device_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## Problem
Environmental sensor entities (temperature, humidity, battery) show state as
'unknown' and display as disconnected dots in the history graph instead of
a continuous line.

![Screenshot 2026-02-13 at 8 03 26 AM](https://github.com/user-attachments/assets/4361bf20-3507-47bf-a4a2-3ae6e418cfd3)
![Screenshot 2026-02-13 at 7 49 11 AM](https://github.com/user-attachments/assets/336f05f1-c189-4957-893e-c41c8ed60891)

## Root Cause
Three related issues in the coordinator:

1. **Missing coordinator initialization** – `async_config_entry_first_refresh()`
   was never called, so the HA DataUpdateCoordinator machinery was not properly
   initialized before entities were created.

2. **MQTT events replacing state instead of merging** – `_on_device_event`
   replaced the entire device state dict with `event.data`. Partial MQTT
   events (connectivity updates, alerts) that don't include sensor readings
   would wipe out previously known temperature/humidity values.

3. **No polling fallback** – No `_async_update_data` was defined and no
   `update_interval` was set, so if MQTT events were missed or the connection
   dropped, there was no way to recover state without restarting HA.

## Fix
- Add `_async_update_data()` with 5-minute HTTP polling interval as fallback
- Call `async_config_entry_first_refresh()` in `__init__.py` to properly
  initialize the coordinator before platforms are set up
- Merge incoming MQTT event data with existing state instead of replacing it

## Files Changed
- `custom_components/yolocal/coordinator.py`
- `custom_components/yolocal/__init__.py`